### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fluidable",
+  "version": "1.2.5",
+  "description": "Lightweight, responsive, mobile first grid system",
+  "main": "fluidable.less",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andri/fluidable.git"
+  },
+  "keywords": [
+    "grid",
+    "fluid",
+    "less"
+  ],
+  "author": "Andri Sigurðsson <andrisig@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/andri/fluidable/issues"
+  },
+  "homepage": "https://github.com/andri/fluidable#readme"
+}


### PR DESCRIPTION
Why:

The be able to publish the package in npm.
This makes it easier for developers using webpack/browserify to import fluidable directly into their projects.

This still requires the package to be published to npm.